### PR TITLE
make it so players can use skills on saves.

### DIFF
--- a/src/CharacterSheet/RollRest.tsx
+++ b/src/CharacterSheet/RollRest.tsx
@@ -70,7 +70,8 @@ export function RollRest({ character, setCharacter, log, setMode }: Props) {
           rounded
           onClick={() => {
             const results = rollSave({
-              save: { value: character[save], name: save },
+	      save: { value: character[save], name: save },
+	      skill: null,
               rollMode,
             });
             log({

--- a/src/CharacterSheet/RollSave.tsx
+++ b/src/CharacterSheet/RollSave.tsx
@@ -2,16 +2,18 @@ import { analyseSaveRoll } from "helpers";
 import { Log } from "Messages/types";
 import { useState } from "react";
 import { allSaves } from "Rules/data";
-import { RollMode, SaveType } from "Rules/types";
+import { CharacterSkill, RollMode, SaveType } from "Rules/types";
 import { rollSave } from "Services/diceServices";
 import { Block, Button, Divider } from "UI/Atoms";
-import { SelectableRating } from "UI/Molecules";
+import { SelectableRating, Skill } from "UI/Molecules";
 import { ReadWriteCharacter, SetMode } from "./types";
+import { allSkillsDict } from "Rules/Data/skills";
 
 interface Props extends ReadWriteCharacter, Log, SetMode {}
 
 export function RollSave({ character, setCharacter, log, setMode }: Props) {
   const [save, setSave] = useState<SaveType>("body");
+  const [skill, setSkill] = useState<CharacterSkill | null>(null);
   const [rollMode, setRollMode] = useState<RollMode>("normal");
 
   return (
@@ -24,6 +26,19 @@ export function RollSave({ character, setCharacter, log, setMode }: Props) {
             value={character[s]}
             onClick={() => setSave(s)}
             selected={s === save}
+          />
+        ))}
+      </div>
+      <Divider />
+      <div className="flex flex-wrap justify-center items-center gap-4">
+        {character.skills.map((s) => (
+          <Skill
+            key={s.type}
+            skill={allSkillsDict[s.type]}
+            onClick={() => {
+              setSkill((ss) => (ss?.type === s.type ? null : s));
+            }}
+            selected={s.type === skill?.type}
           />
         ))}
       </div>
@@ -57,7 +72,8 @@ export function RollSave({ character, setCharacter, log, setMode }: Props) {
           rounded
           onClick={() => {
             const results = rollSave({
-              save: { value: character[save], name: save },
+	      save: { value: character[save], name: save },
+	      skill,
               rollMode,
             });
             log({

--- a/src/Rules/types.ts
+++ b/src/Rules/types.ts
@@ -389,6 +389,7 @@ export interface RollWithMode {
 
 export interface SaveRoll {
   save: { name: SaveType; value: number };
+  skill: CharacterSkill | null;
   rollMode: RollMode;
 }
 
@@ -397,6 +398,8 @@ export interface SaveRollResult extends SaveRoll {
 }
 
 export interface SaveRollAnalysis extends SaveRollResult {
+  skillDefinition: SkillDefinition | null;
+  skillLevel: SkillLevelDefinition | null;
   target: number;
   rollValue: number;
   isSuccess: boolean;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -71,7 +71,7 @@ export function analyseStatRoll(rollResult: StatRollResult): StatRollAnalysis {
 }
 
 export function analyseSaveRoll(rollResult: SaveRollResult): SaveRollAnalysis {
-  const { save, rollMode, result } = rollResult;
+  const { save, skill, rollMode, result } = rollResult;
   let rollValue = result[0];
   if (rollMode === "advantage") {
     rollValue = Math.min(...result);
@@ -79,12 +79,23 @@ export function analyseSaveRoll(rollResult: SaveRollResult): SaveRollAnalysis {
   if (rollMode === "disadvantage") {
     rollValue = Math.max(...result);
   }
-  const target = save.value;
+  const skillDefinition = skill !== null ? allSkillsDict[skill.type] : null;
+  const skillLevel =
+    skillDefinition !== null
+      ? allSkillLevelDefinitionDict[skillDefinition.level]
+      : null;
+  const skillBonus =
+    skill?.lossOfConfidence || skillLevel == null ? 0 : skillLevel.bonus;
+  const target = save.value + skillBonus;
   const isSuccess = rollValue < target;
   const isCritical = rollValue % 11 === 0;
-  const rollDescritpion = `${save.name}${rollModeDescr[rollMode]}`;
+  const skillDescription =
+    skillDefinition !== null ? ` + ${skillDefinition?.name}` : "";
+  const rollDescritpion = `${save.name}${skillDescription}${rollModeDescr[rollMode]}`;
   return {
     ...rollResult,
+    skillDefinition,
+    skillLevel,
     target,
     rollValue,
     isSuccess,


### PR DESCRIPTION
rollSave now takes a skill as an additional argument. Its logic is now identical to rollStat. rollRest must pass a null skill argument, since rest rolls a save without an added skill. This fixes issue #3.