### PR TITLE
src/Services/damageServices.ts: make default gore roll normal.

### DIFF
--- a/src/Services/damageServices.ts
+++ b/src/Services/damageServices.ts
@@ -126,7 +126,7 @@ export function normalizeCriticalType(
     return [{ woundType: "fire", rollMode: "advantage" }];
   }
   if (criticalType === "Gore") {
-    return [{ woundType: "gore", rollMode: "advantage" }];
+    return [{ woundType: "gore", rollMode: "normal" }];
   }
   if (criticalType === "Gore [-]") {
     return [{ woundType: "gore", rollMode: "disadvantage" }];


### PR DESCRIPTION
This was a typo. By default, gore wounds should not be rolled with advantage. This fixes issue #8.